### PR TITLE
Sidewalk lines and buildings placed above streets in Mapbox layers

### DIFF
--- a/index.html
+++ b/index.html
@@ -221,6 +221,10 @@
 	map.addControl(new mapboxgl.NavigationControl());
 
   map.on('load', function() {
+
+		map.moveLayer('turning-feature', 'road-label');
+		map.moveLayer('turning-feature-outline', 'road-label');
+
     // Insert the layer beneath any symbol layer.
     var layers = map.getStyle().layers;
 

--- a/index.html
+++ b/index.html
@@ -222,20 +222,6 @@
 
   map.on('load', function() {
 
-		map.moveLayer('turning-feature', 'road-label');
-		map.moveLayer('turning-feature-outline', 'road-label');
-
-    // Insert the layer beneath any symbol layer.
-    var layers = map.getStyle().layers;
-
-    var labelLayerId;
-    for (var i = 0; i < layers.length; i++) {
-      if (layers[i].type === 'symbol') {
-        labelLayerId = layers[i].id;
-        break;
-      }
-    }
-
 		map.addSource('sidewalks', {
 			 type: 'vector',
 			 url: 'mapbox://transportpartnership.avtbz3wy'
@@ -283,7 +269,7 @@
 					"line-opacity": 0.96
 			}
     },
-    labelLayerId
+    'road-label'
     );
 
     map.addLayer(
@@ -319,7 +305,7 @@
         ]
       }
     },
-    labelLayerId
+    'road-label'
     );
 
     var popup = new mapboxgl.Popup({


### PR DESCRIPTION
I noticed that the colored sidewalk lines and buildings were hidden by the streets (especially when you zoom out). This PR moves the sidewalks and building to the correct position in the Mapbox Layer stack.

![toronto](https://user-images.githubusercontent.com/17068445/80271254-9fa2a000-868c-11ea-83fb-bb6e96e02099.PNG)

The reason this is happening is because the sidewalk lines are placed behind the lowest symbol layer in the Mapbox symbol stack. However, the symbol layers "turning-feature" and "turning-feature-outline" were below all the street layers, creating the problem where streets appeared above the buildings and sidewalk lines.  

Instead, this PR simply uses the "road-label" layer to position to place the sidewalks and buildings. 

The other option you have is to reorder the layers in Mapbox Studio so that "turning-feature" and "turning-feature-outline" are placed above the "road-label" layer in the Mapbox layer stack.